### PR TITLE
Issue  #16: Fix display of long names

### DIFF
--- a/app/src/main/java/ca/rmen/userlist/model/UserIdModel.kt
+++ b/app/src/main/java/ca/rmen/userlist/model/UserIdModel.kt
@@ -1,13 +1,10 @@
 package ca.rmen.userlist.model
 
-import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 data class UserIdModel(
     @SerializedName("name")
     val name: String? = null,
     @SerializedName("value")
     val value: String? = null
-) : Parcelable
+)

--- a/app/src/main/java/ca/rmen/userlist/model/UserModel.kt
+++ b/app/src/main/java/ca/rmen/userlist/model/UserModel.kt
@@ -1,10 +1,7 @@
 package ca.rmen.userlist.model
 
-import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 data class UserModel(
     @SerializedName("name")
     val name: UserNameModel = UserNameModel(),
@@ -17,4 +14,4 @@ data class UserModel(
 
     @SerializedName("phone")
     val phone: String? = null
-) : Parcelable
+)

--- a/app/src/main/java/ca/rmen/userlist/model/UserNameModel.kt
+++ b/app/src/main/java/ca/rmen/userlist/model/UserNameModel.kt
@@ -1,13 +1,10 @@
 package ca.rmen.userlist.model
 
-import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 data class UserNameModel(
     @SerializedName("first")
     val first: String? = null,
     @SerializedName("last")
     val last: String? = null
-) : Parcelable
+)

--- a/app/src/main/java/ca/rmen/userlist/view/DetailsActivity.kt
+++ b/app/src/main/java/ca/rmen/userlist/view/DetailsActivity.kt
@@ -8,28 +8,28 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import ca.rmen.userlist.R
 import ca.rmen.userlist.databinding.UserDetailsBinding
-import ca.rmen.userlist.model.UserModel
+import ca.rmen.userlist.viewmodel.UserDisplayData
 
 class DetailsActivity : AppCompatActivity() {
     companion object {
         private const val EXTRA_USER_DETAILS = "user_details"
-        fun start(context: Context, userModel: UserModel) {
+        fun start(context: Context, userDisplayData: UserDisplayData) {
             val intent = Intent(context, DetailsActivity::class.java)
-                .putExtra(EXTRA_USER_DETAILS, userModel)
+                .putExtra(EXTRA_USER_DETAILS, userDisplayData)
             context.startActivity(intent)
         }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val userModel = intent.getParcelableExtra<UserModel>(EXTRA_USER_DETAILS)!!
+        val userDisplayData = intent.getParcelableExtra<UserDisplayData>(EXTRA_USER_DETAILS)!!
         supportActionBar?.let { actionBar ->
-            actionBar.title = userModel.name.first
+            actionBar.title = userDisplayData.name
             actionBar.setDisplayHomeAsUpEnabled(true)
         }
         val binding =
             DataBindingUtil.setContentView<UserDetailsBinding>(this, R.layout.user_details)
-        binding.data = userModel
+        binding.data = userDisplayData
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/ca/rmen/userlist/view/MainActivity.kt
+++ b/app/src/main/java/ca/rmen/userlist/view/MainActivity.kt
@@ -15,7 +15,7 @@ import androidx.recyclerview.widget.RecyclerView
 import ca.rmen.userlist.R
 import ca.rmen.userlist.databinding.ActivityMainBinding
 import ca.rmen.userlist.databinding.UserListItemBinding
-import ca.rmen.userlist.model.UserModel
+import ca.rmen.userlist.viewmodel.UserDisplayData
 import ca.rmen.userlist.viewmodel.UserListViewModel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -51,19 +51,19 @@ class MainActivity : AppCompatActivity() {
     companion object {
 
         private val DIFF_CALLBACK =
-            object : DiffUtil.ItemCallback<UserModel>() {
-                override fun areItemsTheSame(oldItem: UserModel, newItem: UserModel): Boolean {
+            object : DiffUtil.ItemCallback<UserDisplayData>() {
+                override fun areItemsTheSame(oldItem: UserDisplayData, newItem: UserDisplayData): Boolean {
                     return oldItem.id == newItem.id
                 }
 
-                override fun areContentsTheSame(oldItem: UserModel, newItem: UserModel): Boolean {
+                override fun areContentsTheSame(oldItem: UserDisplayData, newItem: UserDisplayData): Boolean {
                     return oldItem == newItem
                 }
             }
     }
 
     class UsersAdapter :
-        PagingDataAdapter<UserModel, UserViewHolder>(DIFF_CALLBACK) {
+        PagingDataAdapter<UserDisplayData, UserViewHolder>(DIFF_CALLBACK) {
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserViewHolder =
             UserViewHolder(
                 UserListItemBinding.inflate(
@@ -74,11 +74,11 @@ class MainActivity : AppCompatActivity() {
             )
 
         override fun onBindViewHolder(holder: UserViewHolder, position: Int) {
-            val userModel = getItem(position)
-            if (userModel != null) {
-                holder.binding.data = userModel
+            val userDisplayData = getItem(position)
+            if (userDisplayData != null) {
+                holder.binding.data = userDisplayData
                 holder.binding.userCard.setOnClickListener {
-                    DetailsActivity.start(holder.binding.root.context, userModel)
+                    DetailsActivity.start(holder.binding.root.context, userDisplayData)
                 }
             }
         }

--- a/app/src/main/java/ca/rmen/userlist/viewmodel/ApiMapping.kt
+++ b/app/src/main/java/ca/rmen/userlist/viewmodel/ApiMapping.kt
@@ -1,0 +1,14 @@
+package ca.rmen.userlist.viewmodel
+
+import ca.rmen.userlist.model.UserModel
+
+object ApiMapping {
+    fun convert(userModel: UserModel): UserDisplayData =
+        UserDisplayData(
+            id = userModel.id.value ?: "",
+            name = "${userModel.name.first} ${userModel.name.last}",
+            smallAvatarUrl = userModel.picture.thumbnail,
+            largeAvatarUrl = userModel.picture.large,
+            phone = userModel.phone
+        )
+}

--- a/app/src/main/java/ca/rmen/userlist/viewmodel/UserDisplayData.kt
+++ b/app/src/main/java/ca/rmen/userlist/viewmodel/UserDisplayData.kt
@@ -1,0 +1,13 @@
+package ca.rmen.userlist.viewmodel
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class UserDisplayData(
+    val id: String,
+    val name: String,
+    val smallAvatarUrl: String?,
+    val largeAvatarUrl: String?,
+    val phone: String?
+) : Parcelable

--- a/app/src/main/java/ca/rmen/userlist/viewmodel/UserListViewModel.kt
+++ b/app/src/main/java/ca/rmen/userlist/viewmodel/UserListViewModel.kt
@@ -2,7 +2,9 @@ package ca.rmen.userlist.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
+import androidx.paging.map
 import ca.rmen.userlist.model.UserRepository
 
 class UserListViewModel(repository: UserRepository = UserRepository()) : ViewModel() {
@@ -16,5 +18,9 @@ class UserListViewModel(repository: UserRepository = UserRepository()) : ViewMod
         }
     }
 
-    val users = repository.getUsersStream(viewModelScope.coroutineContext)
+    val users = repository.getUsersStream(viewModelScope.coroutineContext).map { pagingData ->
+        pagingData.map {
+            ApiMapping.convert(it)
+        }
+    }
 }

--- a/app/src/main/res/layout/user_details.xml
+++ b/app/src/main/res/layout/user_details.xml
@@ -7,7 +7,7 @@
 
         <variable
             name="data"
-            type="ca.rmen.userlist.model.UserModel" />
+            type="ca.rmen.userlist.viewmodel.UserDisplayData" />
     </data>
 
 
@@ -29,7 +29,7 @@
                 android:layout_marginEnd="16dp"
                 android:adjustViewBounds="true"
                 android:scaleType="center"
-                app:imageUrl="@{data.picture.large}"
+                app:imageUrl="@{data.largeAvatarUrl}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
@@ -43,26 +43,14 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="24dp"
                 android:layout_marginEnd="8dp"
-                android:text="@{data.name.first}"
+                android:text="@{data.name}"
                 android:textAppearance="?attr/textAppearanceHeadline2"
-                app:layout_constraintEnd_toStartOf="@+id/last_name"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_chainStyle="packed"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/avatar"
                 tools:text="@tools:sample/first_names" />
 
-            <TextView
-                android:id="@+id/last_name"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="16dp"
-                android:text="@{data.name.last}"
-                android:textAppearance="?attr/textAppearanceHeadline2"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/first_name"
-                app:layout_constraintTop_toTopOf="@+id/first_name"
-                tools:text="@tools:sample/last_names" />
 
             <TextView
                 android:id="@+id/phone_label"

--- a/app/src/main/res/layout/user_list_item.xml
+++ b/app/src/main/res/layout/user_list_item.xml
@@ -7,7 +7,7 @@
 
         <variable
             name="data"
-            type="ca.rmen.userlist.model.UserModel" />
+            type="ca.rmen.userlist.viewmodel.UserDisplayData" />
     </data>
 
     <FrameLayout
@@ -30,40 +30,27 @@
                     android:layout_width="32dp"
                     android:layout_height="32dp"
                     android:layout_marginStart="16dp"
+                    app:imageUrl="@{data.smallAvatarUrl}"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@+id/first_name"
+                    app:layout_constraintEnd_toStartOf="@+id/name"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:imageUrl="@{data.picture.thumbnail}"
-                    tools:src="@tools:sample/avatars"
-                    tools:ignore="ContentDescription" />
+                    tools:ignore="ContentDescription"
+                    tools:src="@tools:sample/avatars" />
 
                 <TextView
-                    android:id="@+id/first_name"
+                    android:id="@+id/name"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
                     android:layout_marginEnd="8dp"
-                    android:text="@{data.name.first}"
+                    android:text="@{data.name}"
                     android:textAppearance="?attr/textAppearanceListItem"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@+id/last_name"
                     app:layout_constraintStart_toEndOf="@+id/avatar"
                     app:layout_constraintTop_toTopOf="parent"
-                    tools:text="@tools:sample/first_names" />
+                    tools:text="@tools:sample/full_names" />
 
-                <TextView
-                    android:id="@+id/last_name"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:layout_marginEnd="16dp"
-                    android:text="@{data.name.last}"
-                    android:textAppearance="?attr/textAppearanceListItem"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@+id/first_name"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:text="@tools:sample/last_names" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
Create a `UserDisplayData` which a single flat data class containing all the attributes to display for a user. It contains a single `name` field instead of first and last names.

Provide a mapping, between the api model and this ui model.

With the two textviews merged, the text now wraps and the whole name is displayed