### PR TITLE
Issue #26: Make avatars round

### DIFF
--- a/app/src/main/java/ca/rmen/userlist/view/DataBindingAdapters.kt
+++ b/app/src/main/java/ca/rmen/userlist/view/DataBindingAdapters.kt
@@ -3,11 +3,12 @@ package ca.rmen.userlist.view
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CircleCrop
 
 object DataBindingAdapters {
-    @BindingAdapter("app:imageUrl")
+    @BindingAdapter("app:avatarUrl")
     @JvmStatic
-    fun setImageUrl(view: ImageView, url: String?) {
-        Glide.with(view.context).load(url).into(view)
+    fun setAvatarUrl(view: ImageView, url: String?) {
+        Glide.with(view.context).load(url).transform(CircleCrop()).into(view)
     }
 }

--- a/app/src/main/res/layout/user_details.xml
+++ b/app/src/main/res/layout/user_details.xml
@@ -29,7 +29,7 @@
                 android:layout_marginEnd="16dp"
                 android:adjustViewBounds="true"
                 android:scaleType="center"
-                app:imageUrl="@{data.largeAvatarUrl}"
+                app:avatarUrl="@{data.largeAvatarUrl}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/user_list_item.xml
+++ b/app/src/main/res/layout/user_list_item.xml
@@ -33,7 +33,7 @@
                     android:layout_width="32dp"
                     android:layout_height="32dp"
                     android:layout_marginStart="16dp"
-                    app:imageUrl="@{data.smallAvatarUrl}"
+                    app:avatarUrl="@{data.smallAvatarUrl}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toStartOf="@+id/name"
                     app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
* Add a `CircleCrop` transformation to the Glide call to load a url into an imageview.
* Rename this databinding adapter to `avatarUrl`. `imageUrl` was more generic, and doesn't imply a round result, but avatars are typically round.